### PR TITLE
Fixed null content IDs.

### DIFF
--- a/mixer.lua
+++ b/mixer.lua
@@ -216,16 +216,20 @@ wget.callbacks.get_urls = function(file, url, is_css, iri)
     end
     if string.match(url, "^https?://mixer%.com/api/v1/recordings/[0-9]+$") then
       local data = load_json_file(html)
-      if data["contentId"] == nil then
-        abortgrab = true
-        return urls
+	  local contentId = data["contentId"]
+      if contentId == nil then
+        contentId = string.match(data["vods"][1]["baseUrl"], "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x")
+        if contentId == nil then
+          abortgrab = true
+          return urls
+        end
       end
-      ids[data["contentId"]] = true
-      check("https://mixer.com/api/v1/recordings/" .. data["contentId"], true)
-      check("https://mixer.com/api/v2/vods/" .. data["contentId"], true)
+      ids[contentId] = true
+      check("https://mixer.com/api/v1/recordings/" .. contentId, true)
+      check("https://mixer.com/api/v2/vods/" .. contentId, true)
       check("https://mixer.com/api/v2/vods/" .. data["id"], true)
       if current_id == tostring(data["id"]) then
-        current_id = data["contentId"]
+        current_id = contentId
       end
     end
     if string.match(url, "^https?://mixer%.com/api/v2/vods/([^/]+)$") then

--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200721.01'
+VERSION = '20200721.02'
 USER_AGENT = 'Archive Team'
 TRACKER_ID = 'mixer'
 TRACKER_HOST = 'trackerproxy.meo.ws'


### PR DESCRIPTION
If content ID is nil (null in the JSON), extract it from the content URLs. If that also fails, crash as before.