### PR TITLE
Instead of extracting URLs wherever it sees them, follow a fixed cour…

### DIFF
--- a/mixer.lua
+++ b/mixer.lua
@@ -228,6 +228,11 @@ wget.callbacks.get_urls = function(file, url, is_css, iri)
       check("https://mixer.com/api/v1/recordings/" .. contentId, true)
       check("https://mixer.com/api/v2/vods/" .. contentId, true)
       check("https://mixer.com/api/v2/vods/" .. data["id"], true)
+      for index,locator in pairs(data["vods"]) do
+        if locator["format"] == "chat" then
+          check(locator["baseUrl"] .. "source.json", true)
+        end
+      end
       if current_id == tostring(data["id"]) then
         current_id = contentId
       end
@@ -244,27 +249,16 @@ wget.callbacks.get_urls = function(file, url, is_css, iri)
       check("https://mixer.com/api/v2/vods/" .. data["shareableId"], true)
       check("https://mixer.com/api/v2/vods/channels/" .. data["ownerChannelId"], true)
       check("https://mixer.com/api/v1/channels/" .. data["ownerChannelId"], true)
-    end
-    for newurl in string.gmatch(string.gsub(html, "&quot;", '"'), '([^"]+)') do
-      checknewurl(newurl)
-    end
-    for newurl in string.gmatch(string.gsub(html, "&#039;", "'"), "([^']+)") do
-      checknewurl(newurl)
-    end
-    for newurl in string.gmatch(html, ">%s*([^<%s]+)") do
-      checknewurl(newurl)
-    end
-    for newurl in string.gmatch(html, "href='([^']+)'") do
-      checknewshorturl(newurl)
-    end
-    for newurl in string.gmatch(html, "[^%-]href='([^']+)'") do
-      checknewshorturl(newurl)
-    end
-    for newurl in string.gmatch(html, '[^%-]href="([^"]+)"') do
-      checknewshorturl(newurl)
-    end
-    for newurl in string.gmatch(html, ":%s*url%(([^%)]+)%)") do
-      checknewurl(newurl)
+      
+      for index,locator in pairs(data["contentLocators"]) do
+        if locator["locatorType"] == "SmoothStreaming" then
+              check(locator["uri"], true)
+        elseif locator["locatorType"] == "Thumbnail_Large" then
+            check(locator["uri"], true)
+        elseif locator["locatorType"] == "Thumbnail_Small" then
+            check(locator["uri"], true)
+        end
+      end
     end
   end
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200721.02'
+VERSION = '20200721.03'
 USER_AGENT = 'Archive Team'
 TRACKER_ID = 'mixer'
 TRACKER_HOST = 'trackerproxy.meo.ws'


### PR DESCRIPTION
…se around the API.

Strips out part of the script that finds new URLs everywhere, and instead queue new URLs on a source-by-source basis. This fixes both the problem where it would find "URLs" in the middle of big areas of binary video content; and where it would encounter a login page and get stuck there.

Gets significantly less, but gets everything this project wants (video, thumbnails, chat, some stuff for each channel).