### PR TITLE
Skip 400s on /v2/vod/[0-9]+ URLs.

### DIFF
--- a/mixer.lua
+++ b/mixer.lua
@@ -286,6 +286,10 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
       current_id = match
     end
   end
+  
+  if status_code == 400 and string.match(url["url"], "^https?://mixer%.com/api/v2/vods/([0-9]+)$") then
+    return wget.actions.EXIT
+  end
 
   if status_code >= 300 and status_code <= 399 then
     local newloc = string.match(http_stat["newloc"], "^([^#]+)")

--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200723.01'
+VERSION = '20200723.02'
 USER_AGENT = 'Archive Team'
 TRACKER_ID = 'mixer'
 TRACKER_HOST = 'trackerproxy.meo.ws'


### PR DESCRIPTION
These were occuring a lot on some items. Note that this does *not* skip errors on the v2/vod/UUID URLs, which means it is still able to get resources linked from the v2/vod/ endpoint (I have tested this). Nor does it skip anything but a 400. (This means that 429s and the like should still get retried.)